### PR TITLE
Refactor Identity Type Handling to Authsome-Specific Enums

### DIFF
--- a/src/main/java/dev/kuku/authsome/AuthSomeApplication.java
+++ b/src/main/java/dev/kuku/authsome/AuthSomeApplication.java
@@ -16,3 +16,4 @@ public class AuthSomeApplication {
 //NOTE : Hard limit for custom attributes and data that user can put or else they may put huge data
 //NOTE: Max session per project
 //NOTE: BIG!!!!!! Rules engine for complex project
+//NOTE: Asymmetric JWT for project config

--- a/src/main/java/dev/kuku/authsome/cloud/models/SignInRequest.java
+++ b/src/main/java/dev/kuku/authsome/cloud/models/SignInRequest.java
@@ -1,9 +1,9 @@
 package dev.kuku.authsome.cloud.models;
 
-import dev.kuku.authsome.core_service.project.api.dto.IdentityType;
+import dev.kuku.authsome.core_service.authsome.api.dto.AuthsomeUserIdentityType;
 
 public class SignInRequest {
     public String identity;
-    public IdentityType identityType;
+    public AuthsomeUserIdentityType identityType;
     public String password;
 }

--- a/src/main/java/dev/kuku/authsome/cloud/models/SignupStartRequest.java
+++ b/src/main/java/dev/kuku/authsome/cloud/models/SignupStartRequest.java
@@ -1,12 +1,12 @@
 package dev.kuku.authsome.cloud.models;
 
-import dev.kuku.authsome.core_service.project.api.dto.IdentityType;
+import dev.kuku.authsome.core_service.authsome.api.dto.AuthsomeUserIdentityType;
 import lombok.ToString;
 
 @ToString
 public class SignupStartRequest {
     public String identity;
-    public IdentityType identityType;
+    public AuthsomeUserIdentityType identityType;
     public String username;
     public String password;
 }

--- a/src/main/java/dev/kuku/authsome/core_service/authsome/api/AuthsomeService.java
+++ b/src/main/java/dev/kuku/authsome/core_service/authsome/api/AuthsomeService.java
@@ -1,10 +1,9 @@
 package dev.kuku.authsome.core_service.authsome.api;
 
+import dev.kuku.authsome.core_service.authsome.api.dto.AuthsomeUserIdentityType;
 import dev.kuku.authsome.core_service.authsome.api.dto.AuthsomeUserToFetch;
 import dev.kuku.authsome.core_service.authsome.api.dto.SignInTokens;
 import dev.kuku.authsome.core_service.authsome.api.exceptions.*;
-import dev.kuku.authsome.core_service.authsome.api.exceptions.InvalidRefreshToken;
-import dev.kuku.authsome.core_service.project.api.dto.IdentityType;
 import dev.kuku.authsome.util_service.jwt.api.exception.ExpiredJwtToken;
 import dev.kuku.authsome.util_service.jwt.api.exception.InvalidJwtToken;
 import org.apache.coyote.BadRequestException;
@@ -14,48 +13,50 @@ public interface AuthsomeService {
     /**
      * Start signup process and send OTP to identity.
      *
-     * @param identityType
-     * @param identity
-     * @param username
-     * @param password
+     * @param identityType type of the identity
+     * @param identity     identity
+     * @param username     unique username
+     * @param password     password to sign-in with
      * @return token that needs to be passed during verification
      */
-    String startSignupProcess(IdentityType identityType, String identity, String username, String password) throws AuthsomeUsernameAlreadyInUse, AuthsomeIdentityAlreadyInUse, InvalidOtpTypeException;
+    String startSignupProcess(AuthsomeUserIdentityType identityType, String identity, String username, String password) throws AuthsomeUsernameAlreadyInUse, AuthsomeIdentityAlreadyInUse, InvalidOtpTypeException;
 
     /**
      * Complete signup process by verifying that the token and the otp matches. If matches will save the user in the database
      *
-     * @param token
-     * @param otp
+     * @param token token that was returned during {@link AuthsomeService#startSignupProcess}
+     * @param otp   otp that was sent to the identity
      */
     void completeSignupProcess(String token, String otp) throws InvalidJwtToken, ExpiredJwtToken, OtpMismatchException, AuthsomeUsernameAlreadyInUse, AuthsomeIdentityAlreadyInUse, OtpNotFoundInDatabase;
 
     /**
      * Sign in with credential
      *
-     * @param identityType
-     * @param identityValue
-     * @param password
-     * @return access token
+     * @param identityType type of the identity
+     * @param identity     identity logging in with
+     * @param password     password
+     * @return access token and refresh token pair
      */
-    SignInTokens signIn(IdentityType identityType, String identityValue, String password) throws AuthsomeUserWithIdentityNotFound, AuthsomePasswordMismatch, MaxActiveSessionsReached;
+    SignInTokens signIn(AuthsomeUserIdentityType identityType, String identity, String password) throws AuthsomeUserWithIdentityNotFound, AuthsomePasswordMismatch, MaxActiveSessionsReached;
 
     /**
      * Generate new pair of tokens using refreshToken.
      *
-     * @param refreshToken
-     * @return
+     * @param refreshToken valid refresh token
+     * @return new access and refresh token pair
      */
     SignInTokens refreshToken(String refreshToken) throws InvalidRefreshToken;
 
     /**
      * revoke the provided refresh token
+     *
      * @param refreshToken refresh token to revoke
      */
     void revokeRefreshToken(String refreshToken);
 
     /**
      * revoke all refresh token of the provided user
+     *
      * @param userId userId whose refresh token needs to be revoked
      */
     void revokeAllRefreshTokenOfUser(String userId);
@@ -63,8 +64,8 @@ public interface AuthsomeService {
     /**
      * Get the user by id and/or username
      *
-     * @param id
-     * @param username
+     * @param id       id of the user
+     * @param username username of the user
      * @return the fetched user
      */
     @Nullable

--- a/src/main/java/dev/kuku/authsome/core_service/authsome/api/dto/AuthsomeUserIdentityType.java
+++ b/src/main/java/dev/kuku/authsome/core_service/authsome/api/dto/AuthsomeUserIdentityType.java
@@ -1,0 +1,5 @@
+package dev.kuku.authsome.core_service.authsome.api.dto;
+
+public enum AuthsomeUserIdentityType {
+    EMAIL
+}

--- a/src/main/java/dev/kuku/authsome/core_service/authsome/api/exceptions/AuthsomeIdentityAlreadyInUse.java
+++ b/src/main/java/dev/kuku/authsome/core_service/authsome/api/exceptions/AuthsomeIdentityAlreadyInUse.java
@@ -1,8 +1,8 @@
 package dev.kuku.authsome.core_service.authsome.api.exceptions;
 
-import dev.kuku.authsome.core_service.project.api.dto.IdentityType;
+import dev.kuku.authsome.core_service.authsome.api.dto.AuthsomeUserIdentityType;
 
 public class AuthsomeIdentityAlreadyInUse extends AuthsomeException {
-    public AuthsomeIdentityAlreadyInUse(IdentityType identityType, String identity) {
+    public AuthsomeIdentityAlreadyInUse(AuthsomeUserIdentityType identityType, String identity) {
     }
 }

--- a/src/main/java/dev/kuku/authsome/core_service/authsome/api/exceptions/AuthsomePasswordMismatch.java
+++ b/src/main/java/dev/kuku/authsome/core_service/authsome/api/exceptions/AuthsomePasswordMismatch.java
@@ -1,8 +1,8 @@
 package dev.kuku.authsome.core_service.authsome.api.exceptions;
 
-import dev.kuku.authsome.core_service.project.api.dto.IdentityType;
+import dev.kuku.authsome.core_service.authsome.api.dto.AuthsomeUserIdentityType;
 
-public class AuthsomePasswordMismatch extends AuthsomeException{
-    public AuthsomePasswordMismatch(IdentityType identityType, String identityValue) {
+public class AuthsomePasswordMismatch extends AuthsomeException {
+    public AuthsomePasswordMismatch(AuthsomeUserIdentityType identityType, String identityValue) {
     }
 }

--- a/src/main/java/dev/kuku/authsome/core_service/authsome/api/exceptions/AuthsomeUserWithIdentityNotFound.java
+++ b/src/main/java/dev/kuku/authsome/core_service/authsome/api/exceptions/AuthsomeUserWithIdentityNotFound.java
@@ -1,8 +1,8 @@
 package dev.kuku.authsome.core_service.authsome.api.exceptions;
 
-import dev.kuku.authsome.core_service.project.api.dto.IdentityType;
+import dev.kuku.authsome.core_service.authsome.api.dto.AuthsomeUserIdentityType;
 
-public class AuthsomeUserWithIdentityNotFound extends AuthsomeException{
-    public AuthsomeUserWithIdentityNotFound(IdentityType identityType, String identityValue) {
+public class AuthsomeUserWithIdentityNotFound extends AuthsomeException {
+    public AuthsomeUserWithIdentityNotFound(AuthsomeUserIdentityType identityType, String identityValue) {
     }
 }

--- a/src/main/java/dev/kuku/authsome/core_service/authsome/impl/entity/AuthsomeUserIdentityEntity.java
+++ b/src/main/java/dev/kuku/authsome/core_service/authsome/impl/entity/AuthsomeUserIdentityEntity.java
@@ -1,6 +1,6 @@
 package dev.kuku.authsome.core_service.authsome.impl.entity;
 
-import dev.kuku.authsome.core_service.project.api.dto.IdentityType;
+import dev.kuku.authsome.core_service.authsome.api.dto.AuthsomeUserIdentityType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
@@ -29,7 +29,7 @@ public class AuthsomeUserIdentityEntity {
 
     @Column(name = "identity_type", nullable = false)
     @Enumerated(EnumType.STRING)
-    public IdentityType identityType;
+    public AuthsomeUserIdentityType identityType;
 
     @Column(nullable = false, name = "identity")
     public String identity;

--- a/src/main/java/dev/kuku/authsome/core_service/project/api/ProjectService.java
+++ b/src/main/java/dev/kuku/authsome/core_service/project/api/ProjectService.java
@@ -1,6 +1,6 @@
 package dev.kuku.authsome.core_service.project.api;
 
-import dev.kuku.authsome.core_service.project.api.dto.IdentityType;
+import dev.kuku.authsome.core_service.project.api.dto.ProjectUserIdentityType;
 import dev.kuku.authsome.core_service.project.api.dto.ProjectToFetch;
 import dev.kuku.authsome.core_service.project.api.dto.ProjectUserToAdd;
 
@@ -52,11 +52,11 @@ public interface ProjectService {
      *
      * @param projectId
      * @param projectUsername
-     * @param identityType
+     * @param projectUserIdentityType
      * @param identity
      * @return token that must be sent along with the OTP during verification process.
      */
-    String updatePasswordWithIdentityOtp(String projectId, String projectUsername, IdentityType identityType, String identity);
+    String updatePasswordWithIdentityOtp(String projectId, String projectUsername, ProjectUserIdentityType projectUserIdentityType, String identity);
 
     /**
      * Verify the OTP and set new password for the given project authsome_user.
@@ -78,7 +78,7 @@ public interface ProjectService {
      * @param identity         identity value from the identity provider.
      * @param isVerified       if true the identity will be persisted as verified and will not require further verification.
      */
-    void addIdentityForUser(String projectId, String projectUsername, IdentityType identityProvider, String identity, boolean isVerified);
+    void addIdentityForUser(String projectId, String projectUsername, ProjectUserIdentityType identityProvider, String identity, boolean isVerified);
 
     /**
      * Start identity verification process for a authsome_user in a project using OTP as verification method.
@@ -89,7 +89,7 @@ public interface ProjectService {
      * @param identity         identity value from the identity provider.
      * @return token that must be passed during verification of the identity.
      */
-    String startidentityVerificationWithOtp(String projectId, String projectUsername, IdentityType identityProvider, String identity);
+    String startidentityVerificationWithOtp(String projectId, String projectUsername, ProjectUserIdentityType identityProvider, String identity);
 
     /**
      * Verify identity for a authsome_user in a project using OTP as verification method. Will throw except if something went wrong.
@@ -101,7 +101,7 @@ public interface ProjectService {
      * @param otp              one time password sent to the identity.
      * @param token            token received when starting the identity verification process.
      */
-    void verifyIdentityWithOtp(String projectId, String projectUsername, IdentityType identityProvider, String identity, String otp, String token);
+    void verifyIdentityWithOtp(String projectId, String projectUsername, ProjectUserIdentityType identityProvider, String identity, String otp, String token);
 
     /**
      * Get all the projects of a user

--- a/src/main/java/dev/kuku/authsome/core_service/project/api/dto/ProjectUserIdentityType.java
+++ b/src/main/java/dev/kuku/authsome/core_service/project/api/dto/ProjectUserIdentityType.java
@@ -1,5 +1,5 @@
 package dev.kuku.authsome.core_service.project.api.dto;
 
-public enum IdentityType {
+public enum ProjectUserIdentityType {
     EMAIL
 }

--- a/src/main/java/dev/kuku/authsome/core_service/project/internal/entity/ProjectUserIdentityEntity.java
+++ b/src/main/java/dev/kuku/authsome/core_service/project/internal/entity/ProjectUserIdentityEntity.java
@@ -1,6 +1,6 @@
 package dev.kuku.authsome.core_service.project.internal.entity;
 
-import dev.kuku.authsome.core_service.project.api.dto.IdentityType;
+import dev.kuku.authsome.core_service.project.api.dto.ProjectUserIdentityType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
@@ -22,7 +22,7 @@ public class ProjectUserIdentityEntity {
 
     @Column(nullable = false, updatable = false, name = "identity_type")
     @Enumerated(EnumType.STRING)
-    public IdentityType identityType;
+    public ProjectUserIdentityType projectUserIdentityType;
 
     @Column(nullable = false, name = "identity")
     public String identity;

--- a/src/main/java/dev/kuku/authsome/core_service/project/internal/service/ProjectServiceImpl.java
+++ b/src/main/java/dev/kuku/authsome/core_service/project/internal/service/ProjectServiceImpl.java
@@ -1,7 +1,7 @@
 package dev.kuku.authsome.core_service.project.internal.service;
 
 import dev.kuku.authsome.core_service.project.api.ProjectService;
-import dev.kuku.authsome.core_service.project.api.dto.IdentityType;
+import dev.kuku.authsome.core_service.project.api.dto.ProjectUserIdentityType;
 import dev.kuku.authsome.core_service.project.api.dto.ProjectToFetch;
 import dev.kuku.authsome.core_service.project.api.dto.ProjectUserToAdd;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +32,7 @@ public class ProjectServiceImpl implements ProjectService {
     }
 
     @Override
-    public String updatePasswordWithIdentityOtp(String projectId, String projectUsername, IdentityType identityType, String identity) {
+    public String updatePasswordWithIdentityOtp(String projectId, String projectUsername, ProjectUserIdentityType projectUserIdentityType, String identity) {
         return "";
     }
 
@@ -42,17 +42,17 @@ public class ProjectServiceImpl implements ProjectService {
     }
 
     @Override
-    public void addIdentityForUser(String projectId, String projectUsername, IdentityType identityProvider, String identity, boolean isVerified) {
+    public void addIdentityForUser(String projectId, String projectUsername, ProjectUserIdentityType identityProvider, String identity, boolean isVerified) {
 
     }
 
     @Override
-    public String startidentityVerificationWithOtp(String projectId, String projectUsername, IdentityType identityProvider, String identity) {
+    public String startidentityVerificationWithOtp(String projectId, String projectUsername, ProjectUserIdentityType identityProvider, String identity) {
         return "";
     }
 
     @Override
-    public void verifyIdentityWithOtp(String projectId, String projectUsername, IdentityType identityProvider, String identity, String otp, String token) {
+    public void verifyIdentityWithOtp(String projectId, String projectUsername, ProjectUserIdentityType identityProvider, String identity, String otp, String token) {
 
     }
 

--- a/src/main/java/dev/kuku/authsome/util_service/notifier/api/NotifierService.java
+++ b/src/main/java/dev/kuku/authsome/util_service/notifier/api/NotifierService.java
@@ -1,7 +1,8 @@
 package dev.kuku.authsome.util_service.notifier.api;
 
-import dev.kuku.authsome.core_service.project.api.dto.IdentityType;
+
+import dev.kuku.authsome.util_service.notifier.api.dto.NotifierIdentityType;
 
 public interface NotifierService {
-    void sendNotificationToIdentity(IdentityType identityType, String identity, String subject, String content);
+    void sendNotificationToIdentity(NotifierIdentityType notifierIdentityType, String identity, String subject, String content);
 }

--- a/src/main/java/dev/kuku/authsome/util_service/notifier/api/dto/NotifierIdentityType.java
+++ b/src/main/java/dev/kuku/authsome/util_service/notifier/api/dto/NotifierIdentityType.java
@@ -1,0 +1,5 @@
+package dev.kuku.authsome.util_service.notifier.api.dto;
+
+public enum NotifierIdentityType {
+    EMAIL
+}

--- a/src/main/java/dev/kuku/authsome/util_service/notifier/impl/NotifierServiceImpl.java
+++ b/src/main/java/dev/kuku/authsome/util_service/notifier/impl/NotifierServiceImpl.java
@@ -1,13 +1,13 @@
 package dev.kuku.authsome.util_service.notifier.impl;
 
-import dev.kuku.authsome.core_service.project.api.dto.IdentityType;
 import dev.kuku.authsome.util_service.notifier.api.NotifierService;
+import dev.kuku.authsome.util_service.notifier.api.dto.NotifierIdentityType;
 import org.springframework.stereotype.Service;
 
 @Service
 public class NotifierServiceImpl implements NotifierService {
     @Override
-    public void sendNotificationToIdentity(IdentityType identityType, String identity, String subject, String content) {
+    public void sendNotificationToIdentity(NotifierIdentityType identityType, String identity, String subject, String content) {
 
     }
 }

--- a/src/test/java/dev/kuku/authsome/core_services/AuthsomeServiceImplSignupTest.java
+++ b/src/test/java/dev/kuku/authsome/core_services/AuthsomeServiceImplSignupTest.java
@@ -1,17 +1,19 @@
 package dev.kuku.authsome.core_services;
 
+import dev.kuku.authsome.core_service.authsome.api.dto.AuthsomeUserIdentityType;
 import dev.kuku.authsome.core_service.authsome.api.exceptions.*;
 import dev.kuku.authsome.core_service.authsome.impl.AuthsomeServiceImpl;
 import dev.kuku.authsome.core_service.authsome.impl.AuthsomeUserIdentityJpaRepo;
 import dev.kuku.authsome.core_service.authsome.impl.AuthsomeUserJpaRepo;
 import dev.kuku.authsome.core_service.authsome.impl.entity.AuthsomeUserEntity;
 import dev.kuku.authsome.core_service.authsome.impl.entity.AuthsomeUserIdentityEntity;
-import dev.kuku.authsome.core_service.project.api.dto.IdentityType;
+import dev.kuku.authsome.core_service.project.api.dto.ProjectUserIdentityType;
 import dev.kuku.authsome.util_service.jwt.api.JwtService;
 import dev.kuku.authsome.util_service.jwt.api.dto.TokenData;
 import dev.kuku.authsome.util_service.jwt.api.exception.ExpiredJwtToken;
 import dev.kuku.authsome.util_service.jwt.api.exception.InvalidJwtToken;
 import dev.kuku.authsome.util_service.notifier.api.NotifierService;
+import dev.kuku.authsome.util_service.notifier.api.dto.NotifierIdentityType;
 import dev.kuku.authsome.util_service.otp.api.OtpService;
 import dev.kuku.authsome.util_service.otp.api.dto.OtpToFetch;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,15 +60,17 @@ class AuthsomeServiceImplSignupTest {
 
     @BeforeEach
     void setUp() {
-        // Set up configuration values using ReflectionTestUtils
         ReflectionTestUtils.setField(authsomeService, "otpType", "NUMERIC");
         ReflectionTestUtils.setField(authsomeService, "otpLength", 6);
         ReflectionTestUtils.setField(authsomeService, "otpMinNumAlphanumeric", 2);
-        ReflectionTestUtils.setField(authsomeService, "OtpMinCharAlphanumeric", 3);
+        ReflectionTestUtils.setField(authsomeService, "OtpMinCharAlphanumeric", 3); // <-- Correct
         ReflectionTestUtils.setField(authsomeService, "otpExpiry", 5);
         ReflectionTestUtils.setField(authsomeService, "otpExpiryUnitString", "MINUTES");
-        ReflectionTestUtils.setField(authsomeService, "OtpExpiryUnit", TimeUnit.MINUTES);
+        ReflectionTestUtils.setField(authsomeService, "otpExpiryUnit", TimeUnit.MINUTES);
+        ReflectionTestUtils.setField(authsomeService, "log", mock(dev.kuku.vfl.api.annotation.VFLAnnotation.class));
     }
+
+
 
     @Test
     void startSignupProcess_Success_NumericOtp() throws AuthsomeUsernameAlreadyInUse, InvalidOtpTypeException, AuthsomeIdentityAlreadyInUse {
@@ -74,7 +78,7 @@ class AuthsomeServiceImplSignupTest {
         String username = "testuser";
         String password = "password123";
         String identity = "test@example.com";
-        IdentityType identityType = IdentityType.EMAIL;
+        AuthsomeUserIdentityType identityType = AuthsomeUserIdentityType.EMAIL;
         int generatedOtp = 123456;
         String otpId = "otp-id-123";
         String token = "jwt-token-123";
@@ -99,12 +103,12 @@ class AuthsomeServiceImplSignupTest {
         verify(otpService).generateNumericOtp(6);
         verify(otpService).saveOtpWithCustomData(eq(String.valueOf(generatedOtp)), argThat(map ->
                 map.get("username").equals(username) &&
-                map.get("identityType").equals(identityType) &&
+                map.get("projectUserIdentityType").equals(identityType) &&
                 map.get("identityValue").equals(identity) &&
                 map.get("password").equals("hashed-password")
         ), eq(5), eq(TimeUnit.MINUTES));
         verify(notifierService).sendNotificationToIdentity(
-                eq(identityType),
+                eq(NotifierIdentityType.valueOf(identityType.name())),
                 eq(identity),
                 anyString(),
                 contains(String.valueOf(generatedOtp))
@@ -118,7 +122,7 @@ class AuthsomeServiceImplSignupTest {
         String username = "testuser";
         String password = "password123";
         String identity = "test@example.com";
-        IdentityType identityType = IdentityType.EMAIL;
+        AuthsomeUserIdentityType identityType = AuthsomeUserIdentityType.EMAIL;
         String generatedOtp = "AB12CD";
         String otpId = "otp-id-123";
         String token = "jwt-token-123";
@@ -148,7 +152,7 @@ class AuthsomeServiceImplSignupTest {
         String username = "testuser";
         String password = "password123";
         String identity = "test@example.com";
-        IdentityType identityType = IdentityType.EMAIL;
+        AuthsomeUserIdentityType identityType = AuthsomeUserIdentityType.EMAIL;
         String generatedOtp = "ABCDEF";
         String otpId = "otp-id-123";
         String token = "jwt-token-123";
@@ -176,7 +180,7 @@ class AuthsomeServiceImplSignupTest {
         String username = "existinguser";
         String password = "password123";
         String identity = "test@example.com";
-        IdentityType identityType = IdentityType.EMAIL;
+        AuthsomeUserIdentityType identityType = AuthsomeUserIdentityType.EMAIL;
 
         when(userJpaRepo.exists(any(Example.class))).thenReturn(true);
 
@@ -195,7 +199,7 @@ class AuthsomeServiceImplSignupTest {
         String username = "testuser";
         String password = "password123";
         String identity = "existing@example.com";
-        IdentityType identityType = IdentityType.EMAIL;
+        AuthsomeUserIdentityType identityType = AuthsomeUserIdentityType.EMAIL;
 
         when(userJpaRepo.exists(any(Example.class))).thenReturn(false);
         when(identityJpaRepo.exists(any(Example.class))).thenReturn(true);
@@ -216,7 +220,7 @@ class AuthsomeServiceImplSignupTest {
         String username = "testuser";
         String password = "password123";
         String identity = "test@example.com";
-        IdentityType identityType = IdentityType.EMAIL;
+        AuthsomeUserIdentityType identityType = AuthsomeUserIdentityType.EMAIL;
 
         when(userJpaRepo.exists(any(Example.class))).thenReturn(false);
         when(identityJpaRepo.exists(any(Example.class))).thenReturn(false);
@@ -236,7 +240,7 @@ class AuthsomeServiceImplSignupTest {
         String username = "testuser";
         String hashedPassword = "hashed-password";
         String identity = "test@example.com";
-        IdentityType identityType = IdentityType.EMAIL;
+        ProjectUserIdentityType projectUserIdentityType = ProjectUserIdentityType.EMAIL;
         String userId = "user-id-123";
 
         TokenData tokenData = new TokenData(otpId, null);
@@ -247,7 +251,7 @@ class AuthsomeServiceImplSignupTest {
                         "username", username,
                         "password", hashedPassword,
                         "identityValue", identity,
-                        "identityType", identityType.name()
+                        "projectUserIdentityType", projectUserIdentityType.name()
                 )
         );
         AuthsomeUserEntity savedUser = new AuthsomeUserEntity(
@@ -276,7 +280,7 @@ class AuthsomeServiceImplSignupTest {
         ));
         verify(identityJpaRepo).save(argThat(userIdentity ->
                 userIdentity.user.equals(savedUser) &&
-                userIdentity.identityType.equals(identityType) &&
+                userIdentity.identityType.equals(projectUserIdentityType) &&
                 userIdentity.identity.equals(identity)
         ));
         verify(otpService).deleteById(otpId);
@@ -388,7 +392,7 @@ class AuthsomeServiceImplSignupTest {
                         "username", username,
                         "password", "hashed-password",
                         "identityValue", "test@example.com",
-                        "identityType", IdentityType.EMAIL.name()
+                        "projectUserIdentityType", ProjectUserIdentityType.EMAIL.name()
                 )
         );
 


### PR DESCRIPTION


### **PR Title:**

Refactor Identity Type Handling to Use Authsome-Specific Enums

### **Description:**

This PR refactors the authentication and project modules to use dedicated `AuthsomeUserIdentityType` and `ProjectUserIdentityType` enums instead of the previous generic `IdentityType`. This standardizes identity type handling across Authsome services, core project modules, notifier service, and test cases.

### **Changes Included:**

1. **Authsome Core Service:**

    * Introduced `AuthsomeUserIdentityType` enum (`EMAIL` currently).
    * Updated `AuthsomeService` interface and `AuthsomeServiceImpl` to use `AuthsomeUserIdentityType`.
    * Updated related exceptions (`AuthsomeIdentityAlreadyInUse`, `AuthsomePasswordMismatch`, `AuthsomeUserWithIdentityNotFound`) to use the new enum.

2. **Project Core Service:**

    * Renamed `IdentityType` → `ProjectUserIdentityType` for project-specific identity handling.
    * Updated `ProjectService` interface and `ProjectServiceImpl` to reflect this change.
    * Updated `ProjectUserIdentityEntity` to use `ProjectUserIdentityType`.

3. **Notifier Service:**

    * Updated `NotifierService` to use `NotifierIdentityType` enum instead of generic `IdentityType`.

4. **Authsome Application & Cloud Models:**

    * Updated `SignInRequest` and `SignupStartRequest` to use `AuthsomeUserIdentityType`.

5. **Tests:**

    * Updated signup and signin unit tests to use `AuthsomeUserIdentityType` / `ProjectUserIdentityType`.
    * Minor fixes in `ReflectionTestUtils` setup.

6. **Miscellaneous:**

    * Updated all places where identity type was stored in OTP custom data or used in logging/notifications to use the new enums.

### **Why:**

* Previously, `IdentityType` was used inconsistently across modules.
* Using module-specific enums improves type safety, reduces confusion, and prepares the codebase for potential support of multiple identity types in the future.

### **Impact:**

* This is a **breaking change** for any module directly interacting with identity types.
* All references to the old `IdentityType` in Authsome and Project services must now use the corresponding `AuthsomeUserIdentityType` or `ProjectUserIdentityType`.
* Test cases have been updated to reflect these changes.


